### PR TITLE
Support zypper (OpenSUSE package manager)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -24,6 +24,8 @@ LOGS_INSTALL_LOG_FILE_PATH="$LOGS_DIR_PATH/$LOGS_INSTALL_LOG_FILE_NAME"
     elif [[ $(sudo yum help 2>/dev/null) ]]; then
         # yum was replaced with newer dnf above
         sudo yum --y install ibus libevdev python3-devel python3-libevdev
+    elif [[ $(sudo zypper help 2>/dev/null) ]]; then
+        sudo zypper install ibus libevdev2 python3-devel python3-libevdev
     else
         echo "Not detected package manager. Driver may not work properly because required packages have not been installed. Please create an issue (https://github.com/asus-linux-drivers/asus-accel-tablet-mode-driver/issues)."
     fi


### PR DESCRIPTION
Support zypper, which SUSE uses for package management on top of RPM, instead of DNF or YUM.