### PR TITLE
Update asus_accel_driver.py: proper Device initialization

### DIFF
--- a/asus_accel_driver.py
+++ b/asus_accel_driver.py
@@ -108,7 +108,7 @@ for event_to_enable in layout.laptop_mode_events:
     if isEventInput(event_to_enable):
         dev.enable(event_to_enable.code)
 for event_to_enable in layout.tablet_mode_events:
-    if isEventKey(event_to_enable):
+    if isEventInput(event_to_enable):
         dev.enable(event_to_enable.code)
 
 # Sleep for a bit so udev, libinput, Xorg, Wayland, ... all have had


### PR DESCRIPTION
Object of InputEvent has not "name" attribute -> `dev.enable(event_to_enable.code)` will not execute